### PR TITLE
use correct nasdaq benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The dynamic ranking system allows **AmpyFin** to:
   This GET endpoint provides the current holdings of the trading bot.
 
 - **Portfolio & Major ETFs Endpoint**: [https://ampyfin-api-app.onrender.com/portfolio_percentage](https://ampyfin-api-app.onrender.com/portfolio_percentage)  
-  This GET endpoint provides the current total profit percentage of the trading bot since going live. It also provides the current percentage of the portfolio the NDAQ and SPY etfs.
+  This GET endpoint provides the current total profit percentage of the trading bot since going live. It also provides the current percentage for the benchmark QQQ and SPY etfs.
 
 - **Test Endpoint**: [https://ampyfin-api-app.onrender.com/ticker/{ticker}](https://ampyfin-api-app.onrender.com/ticker/)  
   This GET endpoint provides the current sentiment of the trading bot on the particular ticker. Replace {ticker} with an actual ticker symbol. The ticker symbol should be in all caps. It doesn't need to be in the NDAQ-100 but must be listed in the NYSE or NASDAQ.

--- a/trading_client.py
+++ b/trading_client.py
@@ -130,7 +130,7 @@ def main():
                     portfolio_collection = trades_db.portfolio_value
                     portfolio_collection.delete_many({})
                     portfolio_collection.insert_one({'portfolio_percentage': (portfolio_value-50000)/50000})
-                    portfolio_collection.insert_one({'ndaq_percentage': (get_latest_price('NDAQ')-80.08)/80.08})
+                    portfolio_collection.insert_one({'ndaq_percentage': (get_latest_price('QQQ')-80.08)/80.08})
                     portfolio_collection.insert_one({'spy_percentage': (get_latest_price('SPY')-590.50)/590.50})
                     portfolio_collection.insert
                     historical_data = get_historical_data(ticker, data_client)


### PR DESCRIPTION
The Nasdaq benchmark calculation is wrong because the `NDAQ` ticker is the stock ticker for the Nasdaq company, while `QQQ` is the main ETF that tracks the Nasdaq-100. This PR addresses the issue.