### PR TITLE
Remove Polygon.io Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Welcome to **AmpyFin**, an advanced AI-powered trading system designed for the N
 ### 🔍 Data Sources
 
 - **Financial Modeling Prep API**: Retrieves NASDAQ-100 tickers to gain crucial market insights.
-- **Polygon API**: Monitors real-time market conditions, ensuring that the system acts based on the most current data.
 
 ### 💾 Data Storage
 
@@ -135,10 +134,7 @@ pip install -r requirements.txt
 1. **Create `config.py`**:
    - Copy `config_template.py` to `config.py` and enter your API keys and MongoDB credentials.
     ```python
-    POLYGON_API_KEY = "your_polygon_api_key"
     FINANCIAL_PREP_API_KEY = "your_fmp_api_key"
-    MONGO_DB_USER = "your_mongo_user"
-    MONGO_DB_PASS = "your_mongo_password"
     API_KEY = "your_alpaca_api_key"
     API_SECRET = "your_alpaca_secret_key"
     BASE_URL = "https://paper-api.alpaca.markets"
@@ -146,10 +142,6 @@ pip install -r requirements.txt
     ```
 
 ### 4️⃣ API Setup
-
-- Polygon API
-1. Sign up at [Polygon.io](https://polygon.io/) and get an API key.
-2. Add it to `config.py` as `POLYGON_API_KEY`.
 
 - Financial Modeling Prep API
 1. Sign up at [Financial Modeling Prep](https://financialmodelingprep.com/) and get an API key.

--- a/ranking_client.py
+++ b/ranking_client.py
@@ -1,5 +1,4 @@
-from polygon import RESTClient
-from config import POLYGON_API_KEY, FINANCIAL_PREP_API_KEY, MONGO_DB_USER, MONGO_DB_PASS, API_KEY, API_SECRET, BASE_URL, mongo_url
+from config import FINANCIAL_PREP_API_KEY, API_KEY, API_SECRET, BASE_URL, mongo_url
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from urllib.request import urlopen
@@ -45,7 +44,6 @@ import math
 import yfinance as yf
 import logging
 from collections import Counter
-from trading_client import market_status
 from helper_files.client_helper import strategies, get_latest_price, get_ndaq_tickers, dynamic_period_selector
 import time
 from datetime import datetime 
@@ -267,11 +265,11 @@ def update_portfolio_values(client):
       
       for ticker, holding in strategy_doc["holdings"].items():
           # The current price can be gotten through a cache system maybe
-          # if polygon api is getting clogged - but that hasn't happened yet
+          # if yahoo finance is getting clogged - but that hasn't happened yet
           # Also implement in C++ or C instead of python
-          # Get the current price of the ticker from the Polygon API
+          # Get the current price of the ticker from the Yahoo Finance
           # Use a cache system to store the latest prices
-          # If the cache is empty, fetch the latest price from the Polygon API
+          # If the cache is empty, fetch the latest price from the Yahoo Finance
           # Cache should be updated every 60 seconds 
 
           current_price = None
@@ -482,7 +480,7 @@ def main():
          
          return ticker_price_history[ticker].loc[start_date.strftime('%Y-%m-%d'):current_date.strftime('%Y-%m-%d')]
       
-      def update_portfolio_values(current_date):
+      def update_local_portfolio_values(current_date):
          active_count = 0
          for strategy in strategies:
                trading_simulator[strategy.__name__]["portfolio_value"] = trading_simulator[strategy.__name__]["amount_cash"]
@@ -559,7 +557,7 @@ def main():
                         elif trading_simulator[strategy.__name__]["holdings"][ticker]["quantity"] < 0:
                            Exception("Quantity cannot be negative")
                         trading_simulator[strategy.__name__]["total_trades"] += 1
-         active_count = update_portfolio_values(current_date) 
+         active_count = update_local_portfolio_values(current_date) 
          """
          log history of trading_simulator and points
          """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-polygon-api-client
 pymongo
 certifi
 alpaca-py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from config import API_KEY, API_SECRET, POLYGON_API_KEY, MONGO_DB_USER, MONGO_DB_PASS, mongo_url
+from config import API_KEY, API_SECRET, mongo_url
 from helper_files.client_helper import strategies
 from pymongo import MongoClient
 from datetime import datetime

--- a/trading_client.py
+++ b/trading_client.py
@@ -1,6 +1,4 @@
-from polygon import RESTClient
-from config import POLYGON_API_KEY, FINANCIAL_PREP_API_KEY, MONGO_DB_USER, MONGO_DB_PASS, API_KEY, API_SECRET, BASE_URL, mongo_url
-import json
+from config import FINANCIAL_PREP_API_KEY, API_KEY, API_SECRET, BASE_URL, mongo_url
 import certifi
 from urllib.request import urlopen
 from zoneinfo import ZoneInfo
@@ -80,7 +78,7 @@ def weighted_majority_decision_and_median_quantity(decisions_and_quantities):
     else:
         return 'hold', 0, buy_weight, sell_weight, hold_weight
 
-def process_ticker(ticker, client, trading_client, data_client, mongo_client, strategy_to_coefficient):
+def process_ticker(ticker, trading_client, data_client, mongo_client, strategy_to_coefficient):
     global buy_heap
     global suggestion_heap
     global sold
@@ -179,7 +177,6 @@ def main():
         ndaq_tickers = []
         early_hour_first_iteration = True
         post_hour_first_iteration = True
-        client = RESTClient(api_key=POLYGON_API_KEY)
         trading_client = TradingClient(API_KEY, API_SECRET)
         data_client = StockHistoricalDataClient(API_KEY, API_SECRET)
         mongo_client = MongoClient(mongo_url, tlsCAFile=ca)
@@ -189,10 +186,9 @@ def main():
         strategy_to_coefficient = {}
         sold = False
         while True:
-            client = RESTClient(api_key=POLYGON_API_KEY)
             trading_client = TradingClient(API_KEY, API_SECRET)
             data_client = StockHistoricalDataClient(API_KEY, API_SECRET)
-            status = market_status(client)  # Use the helper function for market status
+            status = market_status(trading_client)  # Use the helper function for market status
             db = mongo_client.trades
             asset_collection = db.assets_quantities
             limits_collection = db.assets_limit
@@ -237,7 +233,7 @@ def main():
                 threads = []
 
                 for ticker in ndaq_tickers:
-                    thread = threading.Thread(target=process_ticker, args=(ticker, client, trading_client, data_client, mongo_client, strategy_to_coefficient))
+                    thread = threading.Thread(target=process_ticker, args=(ticker, trading_client, data_client, mongo_client, strategy_to_coefficient))
                     threads.append(thread)
                     thread.start()
 


### PR DESCRIPTION
- Removes polygon.io dependency and associated imports, using the Alpaca clock endpoint
- Manually calculates early_hours value based on the market's next open. See [Alpaca's Extended Hours Trading documentation](https://docs.alpaca.markets/docs/orders-at-alpaca#extended-hours-trading)
- Removes a few unused imports
- Fixes update_portfolio_values function name conflict bug by renaming the non-mongo one to update_local_portfolio_values