### PR TITLE
Added quantstats for tearsheet and metrics

### DIFF
--- a/helper_files/train_client_helper.py
+++ b/helper_files/train_client_helper.py
@@ -3,6 +3,11 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
+import quantstats as qs
+import os
+
+# extend pandas functionality with metrics, etc.
+qs.extend_pandas()
 
 def get_historical_data(ticker, current_date, period, ticker_price_history):
         period_start_date = {
@@ -70,22 +75,18 @@ def plot_cash_growth(account_values):
     plt.grid(True)
     plt.show()
 
-def generate_tear_sheet(account_values, metrics):
-    account_values = account_values.interpolate(method='linear')  # Fill missing values by linear interpolation
-    fig, ax = plt.subplots(2, 1, figsize=(10, 12))
+def generate_tear_sheet(account_values, filename):
+    # Create 'tearsheets' folder if it doesn't exist
+    if not os.path.exists('tearsheets'):
+        os.makedirs('tearsheets')
+
+    # Fill missing values by linear interpolation
+    account_values = account_values.interpolate(method='linear')  
     
-    # Plot account cash growth
-    ax[0].plot(account_values.index, account_values.values, label='Account Portfolio Value')
-    ax[0].set_xlabel('Date')
-    ax[0].set_ylabel('Account Value')
-    ax[0].set_title('Portfolio Value')
-    ax[0].legend()
-    ax[0].grid(True)
-    
-    # Display metrics
-    metrics_text = '\n'.join([f'{k}: {v:.4f}' for k, v in metrics.items()])
-    ax[1].text(0.5, 0.5, metrics_text, fontsize=12, ha='center', va='center', transform=ax[1].transAxes)
-    ax[1].axis('off')
-    
-    plt.tight_layout()
-    plt.show()
+    # Generate quantstats report
+    qs.reports.html(
+        account_values.pct_change(), 
+        "SPY", 
+        title='Strategy vs SPY', 
+        output=f'tearsheets/{filename}.html'
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ripser
 datetime
 TA-Lib
 pandas-ta
+quantstats

--- a/training_client.py
+++ b/training_client.py
@@ -552,11 +552,11 @@ def test():
         time.sleep(5)
     
     """
-    Calculate metrics and generate tear sheet
+    Generate tear sheet
     """
-    metrics = calculate_metrics(account_values)
-    print(metrics)
-    generate_tear_sheet(account_values, metrics)
+    # metrics = calculate_metrics(account_values)
+    # print(metrics)
+    generate_tear_sheet(account_values, 'Strategy_vs_SPY')
 
     """
     print some stats


### PR DESCRIPTION
When we run `training_client.py` in test mode we generate our metrics and tearsheet. 
This can be done through quantstats. 

I have made changes to the `test()` and `generate_tear_sheet()` functions and added quantstats to `requirements.txt`.

However, we need to make one change to quantstats package which can be done through this [https://github.com/ranaroussi/quantstats/issues/399#issuecomment-2666766735](comment) 
