### PR TITLE
bug fix: Remove duplicate code causing keyError

### DIFF
--- a/ranking_client.py
+++ b/ranking_client.py
@@ -225,8 +225,7 @@ def simulate_trade(ticker, strategy, historical_data, current_price, account_cas
          },
          upsert=True
       )
-      if holdings_doc[ticker]["quantity"] == 0:      
-         del holdings_doc[ticker]
+
       # Update cash after selling
       holdings_collection.update_one(
          {"strategy": strategy.__name__},


### PR DESCRIPTION
The code to 'remove ticker from holdings if quantity == 0' is duplicated at line 228-9 and 246-7.
This causes a keyError the second time it runs because the ticker is already removed.

Simply remove duplicate code to fix.

2025-02-20 15:12:48 - ERROR - Traceback (most recent call last):
  File "..\AmpyFin\ranking_client.py", line 122, in process_ticker
    action, quantity = simulate_trade(ticker, strategy, historical_data, current_price,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "..\AmpyFin\ranking_client.py", line 274, in simulate_trade
    if holdings_doc[ticker]["quantity"] == 0:
    ~~~~~~~~~~~~^^^^^^^^
KeyError: 'AMZN'